### PR TITLE
Remove backticks in WhatsApp theme so that it works again under Rambox

### DIFF
--- a/whatsapp/darkmode.css
+++ b/whatsapp/darkmode.css
@@ -1,7 +1,7 @@
   :root:not(#z),
   .dark:not(#z) {
     --version: 'Dark-WhatsApp Lite 3.0.0-rc.6 — August 18th, 2020';
-    --message: 'The v3 is almost here! Updated to `v2.2033.7` of WhatsApp. Delaying the full-release until next week or the week after – see the changelog for more info. ';
+    --message: 'The v3 is almost here! Updated to v2.2033.7 of WhatsApp. Delaying the full-release until next week or the week after – see the changelog for more info. ';
     --changes: '\A\A https://github.com/vednoc/dark-whatsapp';
     --ui-font: 'font_name', Segoe UI, Helvetica Neue, Helvetica, Lucida Grande, Arial, Ubuntu, Cantarell, Fira Sans, sans-serif !important;
     --r-menus: 4px;


### PR DESCRIPTION
Hi, I tried to apply your dark theme for WhatsApp to Rambox, but it had no effect. Looking around in the code, I found a pair of backticks, which conflicts with the backticks that the CSS is wrapped in in `applycss(..)`, so I removed them and now the theme works perfectly :)